### PR TITLE
Make bundle compatible with Symfony 2 and 3 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,13 @@ php:
     - 7.1
 
 install:
-    - composer self-update
-    - composer install --dev --prefer-source
-
-install:
     - git clone --branch trusty --depth=1 https://github.com/rezzza/travis-ci.git ~/.rezzza.travis-ci
-    - ~/.rezzza.travis-ci/php/bootstrap.sh apcu fpm
+    - ~/.rezzza.travis-ci/php/bootstrap.sh fpm
     - phpenv rehash
     - ~/.rezzza.travis-ci/apache/bootstrap.sh 80
     - ln -s ~/build/rezzza/SecurityBundle/features/bootstrap ~/vhosts/security-bundle.vlr.localtest
+    - composer self-update
     - composer install --optimize-autoloader --prefer-dist --no-scripts
-
 
 script:
     - bin/atoum -ulr

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,33 @@ dist: trusty
 sudo: required
 
 cache:
-    apt: true
     directories:
         - vendor
         - bin
 
-addons:
-    hosts:
-        - security-bundle.vlr.localtest
-
 php:
     - 7.1
 
+env:
+    global:
+    - WEBSITE_URL="http://dev.security.com"
+    - WEBSITE_DOMAIN="security.com"
+
 install:
-    - git clone --branch trusty --depth=1 https://github.com/rezzza/travis-ci.git ~/.rezzza.travis-ci
-    - ~/.rezzza.travis-ci/php/bootstrap.sh fpm
-    - phpenv rehash
-    - ~/.rezzza.travis-ci/apache/bootstrap.sh 80
-    - ln -s ~/build/rezzza/SecurityBundle/features/bootstrap ~/vhosts/security-bundle.vlr.localtest
+    - sudo apt-add-repository -y ppa:ondrej/php
+    - sudo apt-get update
+    - sudo apt-get install nginx php7.1-fpm
+    - cd $TRAVIS_BUILD_DIR
+    - sudo cp features/bootstrap/Resources/nginx-conf /etc/nginx/sites-available/$WEBSITE_DOMAIN
+    - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$TRAVIS_BUILD_DIR/features/bootstrap/web?g" --in-place /etc/nginx/sites-available/$WEBSITE_DOMAIN
+    - sudo sed -e "s?%SITE_DOMAIN%?$WEBSITE_DOMAIN?g" --in-place /etc/nginx/sites-available/$WEBSITE_DOMAIN
+    - sudo ln -s /etc/nginx/sites-available/$WEBSITE_DOMAIN /etc/nginx/sites-enabled/
     - composer self-update
     - composer install --optimize-autoloader --prefer-dist --no-scripts
+
+before_script:
+    - sudo service php7.1-fpm restart
+    - sudo service nginx restart
 
 script:
     - bin/atoum -ulr

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,7 @@ addons:
         - security-bundle.vlr.localtest
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
+    - 7.1
 
 install:
     - composer self-update
@@ -36,9 +33,3 @@ script:
     - bin/atoum -ulr
     - bin/behat -f progress -vvv
 
-notifications:
-    email:
-        recipients:
-            - ci@verylastroom.com
-        on_success: change
-        on_failure: change

--- a/DependencyInjection/RezzzaSecurityExtension.php
+++ b/DependencyInjection/RezzzaSecurityExtension.php
@@ -47,6 +47,7 @@ class RezzzaSecurityExtension extends Extension
             $definition->addArgument($data['replay_protection']);
             $definition->addArgument($data['algorithm']);
             $definition->addArgument($data['secret']);
+            $definition->setPublic(true);
 
             $container->setDefinition($serviceName, $definition);
         }

--- a/DependencyInjection/Security/Factory/RequestSignatureFactory.php
+++ b/DependencyInjection/Security/Factory/RequestSignatureFactory.php
@@ -5,6 +5,7 @@ namespace Rezzza\SecurityBundle\DependencyInjection\Security\Factory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 
@@ -18,14 +19,14 @@ class RequestSignatureFactory implements SecurityFactoryInterface
         $providerId = 'security.authentication.provider.request_signature.'.$id;
 
         $container
-            ->setDefinition($providerId, new ChildDefinition('rezzza.security.request_signature.provider'))
+            ->setDefinition($providerId, $this->createDefinition('rezzza.security.request_signature.provider'))
             ->addArgument(new Reference($signatureConfigId))
             ->addArgument(new Reference($replayProtectionId))
         ;
 
         $listenerId = 'security.authentication.listener.request_signature.'.$id;
         $listener = $container
-            ->setDefinition($listenerId, new ChildDefinition('rezzza.security.request_signature.listener'))
+            ->setDefinition($listenerId, $this->createDefinition('rezzza.security.request_signature.listener'))
             ->replaceArgument(2, new Reference($signatureQueryParametersId))
             ->replaceArgument(3, $config['ignore'])
         ;
@@ -47,7 +48,7 @@ class RequestSignatureFactory implements SecurityFactoryInterface
     {
         $signatureConfigId = 'rezzza.security.request_signature.signature_config.'.$id;
         $container
-            ->setDefinition($signatureConfigId, new ChildDefinition('rezzza.security.request_signature.signature_config'))
+            ->setDefinition($signatureConfigId, $this->createDefinition('rezzza.security.request_signature.signature_config'))
             ->addArgument($config['replay_protection']['enabled'])
             ->addArgument($config['algorithm'])
             ->addArgument($config['secret'])
@@ -60,7 +61,7 @@ class RequestSignatureFactory implements SecurityFactoryInterface
     {
         $signatureQueryParametersId = 'rezzza.security.request_signature.signature_query_parameters.'.$id;
         $container
-            ->setDefinition($signatureQueryParametersId, new ChildDefinition('rezzza.security.request_signature.signature_query_parameters'))
+            ->setDefinition($signatureQueryParametersId, $this->createDefinition('rezzza.security.request_signature.signature_query_parameters'))
             ->addArgument($config['parameter'])
             ->addArgument($config['replay_protection']['parameter'])
         ;
@@ -72,7 +73,7 @@ class RequestSignatureFactory implements SecurityFactoryInterface
     {
         $replayProtectionId = 'rezzza.security.request_signature.replay_protection.'.$id;
         $container
-            ->setDefinition($replayProtectionId, new ChildDefinition('rezzza.security.request_signature.replay_protection'))
+            ->setDefinition($replayProtectionId, $this->createDefinition('rezzza.security.request_signature.replay_protection'))
             ->addArgument($config['replay_protection']['enabled'])
             ->addArgument($config['replay_protection']['lifetime'])
         ;
@@ -96,5 +97,18 @@ class RequestSignatureFactory implements SecurityFactoryInterface
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * @param $serviceId
+     * @return ChildDefinition|DefinitionDecorator
+     */
+    private function createDefinition($serviceId)
+    {
+        if (class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')) {
+            return new \Symfony\Component\DependencyInjection\ChildDefinition($serviceId);
+        } else {
+            return new \Symfony\Component\DependencyInjection\DefinitionDecorator($serviceId);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 SecurityBundle
 ==============
 
-[![Build Status](https://travis-ci.org/rezzza/SecurityBundle.svg?branch=master)](https://travis-ci.org/rezzza/SecurityBundle)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/rezzza/SecurityBundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/rezzza/SecurityBundle/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/rezzza/SecurityBundle/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/rezzza/SecurityBundle/?branch=master)
+[![Build Status](https://travis-ci.com/inextensodigital/SecurityBundle.svg?branch=master)](https://travis-ci.com/inextensodigital/SecurityBundle)
+
+This bundle is a fork of [rezzza/SecurityBundle](https://github.com/rezzza/SecurityBundle).
 
 # Installation
 
@@ -11,7 +11,7 @@ SecurityBundle
 
 ```json
     "require": {
-        'rezzza/security-bundle': '~2.0',
+        'inextensodigital/security-bundle': '~4.0',
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This bundle is a fork of [rezzza/SecurityBundle](https://github.com/rezzza/Secur
 
 ```json
     "require": {
-        'inextensodigital/security-bundle': '~4.0',
+        "inextensodigital/security-bundle": "~4.0",
     }
 ```
 

--- a/Security/Authentication/Provider/RequestSignatureProvider.php
+++ b/Security/Authentication/Provider/RequestSignatureProvider.php
@@ -5,7 +5,7 @@ namespace Rezzza\SecurityBundle\Security\Authentication\Provider;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Exception\NonceExpiredException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Rezzza\SecurityBundle\Security\RequestSignatureToken;
 use Rezzza\SecurityBundle\Security\SignatureValidToken;
 use Rezzza\SecurityBundle\Security\Firewall\SignedRequest;
@@ -43,7 +43,7 @@ class RequestSignatureProvider implements AuthenticationProviderInterface
         } catch (InvalidSignatureException $e) {
             throw new AuthenticationException('Invalid signature', null, $e);
         } catch (ExpiredSignatureException $e) {
-            throw new NonceExpiredException($e->getMessage(), null, $e);
+            throw new BadCredentialsException($e->getMessage(), null, $e);
         }
     }
 

--- a/behat.yml
+++ b/behat.yml
@@ -18,7 +18,7 @@ default:
                 env: "test"
                 debug: true
         Behat\MinkExtension:
-            base_url:  "http://security-bundle.vlr.localtest"
+            base_url:  "http://dev.security.com"
             sessions:
                 default:
-                    goutte: ~
+                    symfony2: ~

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }],
     "require": {
         "php": ">=5.5",
-        "symfony/framework-bundle": "~4.0",
+        "symfony/framework-bundle": "~2.6|~3.0|~4.0",
         "symfony/security-bundle" : "~2.6|~3.0|~4.0",
         "doctrine/common": "~2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "homepage": "https://github.com/inextensodigital/SecurityBundle/contributors"
     }],
     "require": {
-        "php": ">=5.5",
+        "php": "~7.1.3",
         "symfony/framework-bundle": "~2.6|~3.0|~4.0",
         "symfony/security-bundle" : "~2.6|~3.0|~4.0",
         "doctrine/common": "~2.2"

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         "homepage": "https://github.com/inextensodigital/SecurityBundle/contributors"
     }],
     "require": {
-        "php": "~7.1.3",
+        "php": ">7.1.3",
         "symfony/framework-bundle": "~2.6|~3.0|~4.0",
         "symfony/security-bundle" : "~2.6|~3.0|~4.0",
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "atoum/atoum": "~2.0",
+        "atoum/atoum": "~3.0",
         "behat/behat": "~3.0",
         "behat/symfony2-extension": "~2.0",
         "behat/mink-extension": "~2.0",

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -61,7 +61,7 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
 
     private function buildSignature($url, $timestamp)
     {
-        $signedRequest = new SignedRequest('GET', 'security-bundle.vlr.localtest', $url, '', $timestamp);
+        $signedRequest = new SignedRequest('GET', 'dev.security.com', $url, '', $timestamp);
 
         return $signedRequest->buildSignature($this->signatureConfig);
     }

--- a/features/bootstrap/Resources/nginx-conf
+++ b/features/bootstrap/Resources/nginx-conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+
+    server_name %SITE_DOMAIN% *.%SITE_DOMAIN%;
+    root %TRAVIS_BUILD_DIR%;
+
+    index index.php;
+
+    error_log /var/log/nginx/security.error.log;
+    access_log /var/log/nginx/security.access.log;
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ ^/index\.php(/|$) {
+        fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTPS off;
+    }
+}

--- a/features/bootstrap/app/config/config.yml
+++ b/features/bootstrap/app/config/config.yml
@@ -3,6 +3,7 @@ imports:
 
 framework:
     secret: test_blah
+    test: ~
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: "%kernel.debug%"

--- a/features/bootstrap/app/config/config.yml
+++ b/features/bootstrap/app/config/config.yml
@@ -10,7 +10,6 @@ framework:
     csrf_protection: true
     validation: false
     default_locale: en
-    trusted_proxies: ~
     session: ~
 
 rezzza_security:

--- a/features/bootstrap/web/index.php
+++ b/features/bootstrap/web/index.php
@@ -5,7 +5,6 @@ require_once __DIR__.'/../app/autoload.php';
 require_once __DIR__.'/../app/AppKernel.php';
 
 $kernel = new AppKernel('test', false);
-$kernel->loadClassCache();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
See https://github.com/inextensodigital/SecurityBundle/releases/tag/4.0

* Make bundle compatible with Symfony 2 and 3 again
* Remove old PHP version support
* Make bundle compatible with PHP 7 :
    * Update README
    * Use atoum 3.3.0
    * Remove apcu from travis scripts
    * Remove deprecated exception from Symfony
* Use simple nginx configuration  : 
    * Remove deprecated bundle using apache
    * Update travis install