### PR TITLE
[Fix] Fix caused by Symfony 7.3 upgrade

### DIFF
--- a/Security/SignatureValidToken.php
+++ b/Security/SignatureValidToken.php
@@ -10,6 +10,7 @@ class SignatureValidToken extends AbstractToken
 {
     public function __construct(SignatureValidUser $user)
     {
+        parent::__construct();
         $this->setUser($user);
     }
 


### PR DESCRIPTION
Missing parent constructor call in `SignatureValidToken` regressed with `AbstractToken` in SF 7.3 [(PR)](https://github.com/symfony/security-core/commit/3062fe62a6261d1e8a6bea0636d9c03f6b2ba684)

[Sentry](https://fulll.sentry.io/issues/6644882575/events/?end=2025-05-30T15%3A54%3A00&project=4507096128749568&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&start=2025-05-30T09%3A51%3A00&stream_index=0): `Typed property Symfony\Component\Security\Core\Authentication\Token\AbstractToken::$roleNames must not be accessed before initialization`

